### PR TITLE
chore: version bump and cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rmqtt-storage"
-version = "0.7.2"
+version = "0.7.3"
 authors = ["rmqtt <rmqttd@126.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/src/storage_redis_cluster.rs
+++ b/src/storage_redis_cluster.rs
@@ -2090,9 +2090,3 @@ fn transform_by_slot<T>(input: Vec<(u16, T)>) -> Vec<Vec<T>> {
 
     grouped_data.into_values().collect()
 }
-
-const _: () = {
-    if cfg!(feature = "len") {
-        panic!("The `len` feature is not allowed in this file.");
-    }
-};


### PR DESCRIPTION
- Bumped version from 0.7.2 to 0.7.3
- Removed redundant feature check in redis-cluster module