### PR TITLE
refactor(storage): migrate serialization from bincode to postcard

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rmqtt-storage"
-version = "0.7.4"
+version = "0.8.0"
 authors = ["rmqtt <rmqttd@126.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -36,7 +36,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0"
 async-trait = "0.1"
-bincode = "1.3"
+postcard = { version = "1.1", features = ["use-std"] }
 log = "0.4"
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 dashmap = "6.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1071,7 +1071,7 @@ mod tests {
     //     map1.retain(|item| {
     //         let res = match item {
     //             Ok((_k, v)) => {
-    //                 let v = bincode::deserialize::<usize>(v.as_ref()).unwrap();
+    //                 let v = postcard::from_bytes::<usize>(v.as_ref()).unwrap();
     //                 v != 10
     //             }
     //             Err(e) => {

--- a/src/storage_redis.rs
+++ b/src/storage_redis.rs
@@ -227,14 +227,14 @@ impl RedisStorageDB {
                 let mut async_conn = self.async_conn();
                 pipe()
                     .atomic()
-                    .set(full_key.as_slice(), bincode::serialize(val)?)
+                    .set(full_key.as_slice(), postcard::to_stdvec(&val)?)
                     .pexpire(full_key.as_slice(), expire_interval)
                     .query_async::<()>(&mut async_conn)
                     .await?;
             } else {
                 let _: () = self
                     .async_conn()
-                    .set(full_key, bincode::serialize(val)?)
+                    .set(full_key, postcard::to_stdvec(&val)?)
                     .await?;
             }
         }
@@ -245,7 +245,7 @@ impl RedisStorageDB {
             if let Some(expire_interval) = expire_interval {
                 pipe()
                     .atomic()
-                    .set(full_key.as_slice(), bincode::serialize(val)?)
+                    .set(full_key.as_slice(), postcard::to_stdvec(&val)?)
                     .pexpire(full_key.as_slice(), expire_interval)
                     .zadd(db_zkey, key.as_ref(), timestamp_millis() + expire_interval)
                     .query_async::<()>(&mut async_conn)
@@ -253,7 +253,7 @@ impl RedisStorageDB {
             } else {
                 pipe()
                     .atomic()
-                    .set(full_key.as_slice(), bincode::serialize(val)?)
+                    .set(full_key.as_slice(), postcard::to_stdvec(&val)?)
                     .zadd(db_zkey, key.as_ref(), i64::MAX)
                     .query_async::<()>(&mut async_conn)
                     .await?;
@@ -616,7 +616,7 @@ impl StorageDB for RedisStorageDB {
             .get::<_, Option<Vec<u8>>>(full_key)
             .await?
         {
-            Ok(Some(bincode::deserialize::<V>(v.as_ref())?))
+            Ok(Some(postcard::from_bytes::<V>(v.as_ref())?))
         } else {
             Ok(None)
         }
@@ -641,7 +641,7 @@ impl StorageDB for RedisStorageDB {
             let keys_vals_expires = key_vals
                 .into_iter()
                 .map(|(k, v)| {
-                    bincode::serialize(&v)
+                    postcard::to_stdvec(&v)
                         .map(move |v| (k, v, None))
                         .map_err(|e| anyhow!(e))
                 })
@@ -1025,7 +1025,7 @@ impl Map for RedisStorageMap {
         K: AsRef<[u8]> + Sync + Send,
         V: Serialize + Sync + Send + ?Sized,
     {
-        self._insert_expire(key.as_ref(), bincode::serialize(val)?)
+        self._insert_expire(key.as_ref(), postcard::to_stdvec(&val)?)
             .await
     }
 
@@ -1041,7 +1041,7 @@ impl Map for RedisStorageMap {
             .hget(self.full_name.as_slice(), key.as_ref())
             .await?;
         if let Some(res) = res {
-            Ok(Some(bincode::deserialize::<V>(res.as_ref())?))
+            Ok(Some(postcard::from_bytes::<V>(res.as_ref())?))
         } else {
             Ok(None)
         }
@@ -1115,7 +1115,7 @@ impl Map for RedisStorageMap {
             .await?;
 
         if let Some(res) = res {
-            Ok(Some(bincode::deserialize::<V>(res.as_ref())?))
+            Ok(Some(postcard::from_bytes::<V>(res.as_ref())?))
         } else {
             Ok(None)
         }
@@ -1161,7 +1161,7 @@ impl Map for RedisStorageMap {
             let key_vals = key_vals
                 .into_iter()
                 .map(|(k, v)| {
-                    bincode::serialize(&v)
+                    postcard::to_stdvec(&v)
                         .map(move |v| (k, v))
                         .map_err(|e| anyhow!(e))
                 })
@@ -1476,7 +1476,7 @@ impl List for RedisStorageList {
     where
         V: Serialize + Sync + Send,
     {
-        self._push_expire(bincode::serialize(val)?).await
+        self._push_expire(postcard::to_stdvec(&val)?).await
     }
 
     /// Pushes multiple values to the end of the list
@@ -1487,7 +1487,7 @@ impl List for RedisStorageList {
     {
         let vals = vals
             .into_iter()
-            .map(|v| bincode::serialize(&v).map_err(|e| anyhow!(e)))
+            .map(|v| postcard::to_stdvec(&v).map_err(|e| anyhow!(e)))
             .collect::<Result<Vec<_>>>()?;
         self._pushs_expire(vals).await
     }
@@ -1504,14 +1504,14 @@ impl List for RedisStorageList {
         V: Serialize + Sync + Send,
         V: DeserializeOwned,
     {
-        let data = bincode::serialize(val)?;
+        let data = postcard::to_stdvec(&val)?;
 
         if let Some(res) = self
             ._push_limit_expire(data, limit, pop_front_if_limited)
             .await?
         {
             Ok(Some(
-                bincode::deserialize::<V>(res.as_ref()).map_err(|e| anyhow!(e))?,
+                postcard::from_bytes::<V>(res.as_ref()).map_err(|e| anyhow!(e))?,
             ))
         } else {
             Ok(None)
@@ -1530,7 +1530,7 @@ impl List for RedisStorageList {
             .await?;
 
         let removed = if let Some(v) = removed {
-            Some(bincode::deserialize::<V>(v.as_ref()).map_err(|e| anyhow!(e))?)
+            Some(postcard::from_bytes::<V>(v.as_ref()).map_err(|e| anyhow!(e))?)
         } else {
             None
         };
@@ -1549,7 +1549,7 @@ impl List for RedisStorageList {
             .lrange::<_, Vec<Vec<u8>>>(self.full_name.as_slice(), 0, -1)
             .await?;
         all.iter()
-            .map(|v| bincode::deserialize::<V>(v.as_ref()).map_err(|e| anyhow!(e)))
+            .map(|v| postcard::from_bytes::<V>(v.as_ref()).map_err(|e| anyhow!(e)))
             .collect::<Result<Vec<_>>>()
     }
 
@@ -1565,7 +1565,7 @@ impl List for RedisStorageList {
             .await?;
 
         Ok(if let Some(v) = val {
-            Some(bincode::deserialize::<V>(v.as_ref()).map_err(|e| anyhow!(e))?)
+            Some(postcard::from_bytes::<V>(v.as_ref()).map_err(|e| anyhow!(e))?)
         } else {
             None
         })
@@ -1675,7 +1675,7 @@ where
 
     async fn next(&mut self) -> Option<Self::Item> {
         if let Some(val) = self.catch_vals.pop() {
-            return Some(bincode::deserialize::<V>(val.as_ref()).map_err(|e| anyhow!(e)));
+            return Some(postcard::from_bytes::<V>(val.as_ref()).map_err(|e| anyhow!(e)));
         }
 
         let vals = self
@@ -1697,7 +1697,7 @@ where
 
         self.catch_vals
             .pop()
-            .map(|val| bincode::deserialize::<V>(val.as_ref()).map_err(|e| anyhow!(e)))
+            .map(|val| postcard::from_bytes::<V>(val.as_ref()).map_err(|e| anyhow!(e)))
     }
 }
 
@@ -1718,7 +1718,7 @@ where
         match self.iter.next_item().await {
             None => None,
             Some(Err(e)) => Some(Err(anyhow::Error::new(e))),
-            Some(Ok((key, v))) => match bincode::deserialize::<V>(v.as_ref()) {
+            Some(Ok((key, v))) => match postcard::from_bytes::<V>(v.as_ref()) {
                 Ok(v) => Some(Ok((key, v))),
                 Err(e) => Some(Err(anyhow::Error::new(e))),
             },

--- a/src/storage_redis_cluster.rs
+++ b/src/storage_redis_cluster.rs
@@ -303,14 +303,14 @@ impl RedisStorageDB {
                 let mut async_conn = self.async_conn();
                 pipe()
                     .atomic()
-                    .set(full_key.as_slice(), bincode::serialize(_val)?)
+                    .set(full_key.as_slice(), postcard::to_stdvec(&_val)?)
                     .pexpire(full_key.as_slice(), expire_interval)
                     .query_async::<()>(&mut async_conn)
                     .await?;
             } else {
                 let _: () = self
                     .async_conn()
-                    .set(full_key, bincode::serialize(_val)?)
+                    .set(full_key, postcard::to_stdvec(&_val)?)
                     .await?;
             }
         }
@@ -327,7 +327,7 @@ impl RedisStorageDB {
                     if let Some(expire_interval) = _expire_interval {
                         pipe()
                             .atomic()
-                            .set(full_key.as_slice(), bincode::serialize(_val)?)
+                            .set(full_key.as_slice(), postcard::to_stdvec(&_val)?)
                             .pexpire(full_key.as_slice(), expire_interval)
                             .zadd(db_zkey, _key.as_ref(), timestamp_millis() + expire_interval)
                             .query_async::<()>(&mut async_conn)
@@ -335,7 +335,7 @@ impl RedisStorageDB {
                     } else {
                         pipe()
                             .atomic()
-                            .set(full_key.as_slice(), bincode::serialize(_val)?)
+                            .set(full_key.as_slice(), postcard::to_stdvec(&_val)?)
                             .zadd(db_zkey, _key.as_ref(), i64::MAX)
                             .query_async::<()>(&mut async_conn)
                             .await?;
@@ -345,7 +345,7 @@ impl RedisStorageDB {
                     if let Some(expire_interval) = _expire_interval {
                         let _: () = pipe()
                             .atomic()
-                            .set(full_key.as_slice(), bincode::serialize(_val)?)
+                            .set(full_key.as_slice(), postcard::to_stdvec(&_val)?)
                             .pexpire(full_key.as_slice(), expire_interval)
                             .query_async(&mut async_conn)
                             .await?;
@@ -354,7 +354,7 @@ impl RedisStorageDB {
                             .await?;
                     } else {
                         let _: () = async_conn
-                            .set(full_key.as_slice(), bincode::serialize(_val)?)
+                            .set(full_key.as_slice(), postcard::to_stdvec(&_val)?)
                             .await?;
                         let _: () = async_conn.zadd(db_zkey, _key.as_ref(), i64::MAX).await?;
                     }
@@ -379,7 +379,7 @@ impl RedisStorageDB {
             let keys_vals: Vec<(&Key, Vec<u8>)> = _key_val_expires
                 .iter()
                 .map(|(_, full_key, v, _)| {
-                    bincode::serialize(&v)
+                    postcard::to_stdvec(&&v)
                         .map(move |v| (full_key, v))
                         .map_err(|e| anyhow!(e))
                 })
@@ -790,7 +790,7 @@ impl StorageDB for RedisStorageDB {
             .get::<_, Option<Vec<u8>>>(full_key)
             .await?
         {
-            Ok(Some(bincode::deserialize::<V>(v.as_ref())?))
+            Ok(Some(postcard::from_bytes::<V>(v.as_ref())?))
         } else {
             Ok(None)
         }
@@ -1248,7 +1248,7 @@ impl Map for RedisStorageMap {
         K: AsRef<[u8]> + Sync + Send,
         V: Serialize + Sync + Send + ?Sized,
     {
-        self._insert_expire(key.as_ref(), bincode::serialize(val)?)
+        self._insert_expire(key.as_ref(), postcard::to_stdvec(&val)?)
             .await
     }
 
@@ -1265,7 +1265,7 @@ impl Map for RedisStorageMap {
             .hget(self.full_name.as_slice(), key.as_ref())
             .await?;
         if let Some(res) = res {
-            Ok(Some(bincode::deserialize::<V>(res.as_ref())?))
+            Ok(Some(postcard::from_bytes::<V>(res.as_ref())?))
         } else {
             Ok(None)
         }
@@ -1346,7 +1346,7 @@ impl Map for RedisStorageMap {
             .await?;
 
         if let Some(res) = res {
-            Ok(Some(bincode::deserialize::<V>(res.as_ref())?))
+            Ok(Some(postcard::from_bytes::<V>(res.as_ref())?))
         } else {
             Ok(None)
         }
@@ -1392,7 +1392,7 @@ impl Map for RedisStorageMap {
             let key_vals = key_vals
                 .into_iter()
                 .map(|(k, v)| {
-                    bincode::serialize(&v)
+                    postcard::to_stdvec(&&v)
                         .map(move |v| (k, v))
                         .map_err(|e| anyhow!(e))
                 })
@@ -1713,7 +1713,7 @@ impl List for RedisStorageList {
     where
         V: Serialize + Sync + Send,
     {
-        self._push_expire(bincode::serialize(val)?).await
+        self._push_expire(postcard::to_stdvec(&val)?).await
     }
 
     /// Pushes multiple values to the end of the list
@@ -1725,7 +1725,7 @@ impl List for RedisStorageList {
         //RPUSH key value [value ...]
         let vals = vals
             .into_iter()
-            .map(|v| bincode::serialize(&v).map_err(|e| anyhow!(e)))
+            .map(|v| postcard::to_stdvec(&&v).map_err(|e| anyhow!(e)))
             .collect::<Result<Vec<_>>>()?;
         self._pushs_expire(vals).await
     }
@@ -1742,14 +1742,14 @@ impl List for RedisStorageList {
         V: Serialize + Sync + Send,
         V: DeserializeOwned,
     {
-        let data = bincode::serialize(val)?;
+        let data = postcard::to_stdvec(&val)?;
 
         if let Some(res) = self
             ._push_limit_expire(data, limit, pop_front_if_limited)
             .await?
         {
             Ok(Some(
-                bincode::deserialize::<V>(res.as_ref()).map_err(|e| anyhow!(e))?,
+                postcard::from_bytes::<V>(res.as_ref()).map_err(|e| anyhow!(e))?,
             ))
         } else {
             Ok(None)
@@ -1769,7 +1769,7 @@ impl List for RedisStorageList {
             .await?;
 
         let removed = if let Some(v) = removed {
-            Some(bincode::deserialize::<V>(v.as_ref()).map_err(|e| anyhow!(e))?)
+            Some(postcard::from_bytes::<V>(v.as_ref()).map_err(|e| anyhow!(e))?)
         } else {
             None
         };
@@ -1789,7 +1789,7 @@ impl List for RedisStorageList {
             .lrange::<_, Vec<Vec<u8>>>(self.full_name.as_slice(), 0, -1)
             .await?;
         all.iter()
-            .map(|v| bincode::deserialize::<V>(v.as_ref()).map_err(|e| anyhow!(e)))
+            .map(|v| postcard::from_bytes::<V>(v.as_ref()).map_err(|e| anyhow!(e)))
             .collect::<Result<Vec<_>>>()
     }
 
@@ -1806,7 +1806,7 @@ impl List for RedisStorageList {
             .await?;
 
         Ok(if let Some(v) = val {
-            Some(bincode::deserialize::<V>(v.as_ref()).map_err(|e| anyhow!(e))?)
+            Some(postcard::from_bytes::<V>(v.as_ref()).map_err(|e| anyhow!(e))?)
         } else {
             None
         })
@@ -1916,7 +1916,7 @@ where
 
     async fn next(&mut self) -> Option<Self::Item> {
         if let Some(val) = self.catch_vals.pop() {
-            return Some(bincode::deserialize::<V>(val.as_ref()).map_err(|e| anyhow!(e)));
+            return Some(postcard::from_bytes::<V>(val.as_ref()).map_err(|e| anyhow!(e)));
         }
 
         let vals = self
@@ -1938,7 +1938,7 @@ where
 
         self.catch_vals
             .pop()
-            .map(|val| bincode::deserialize::<V>(val.as_ref()).map_err(|e| anyhow!(e)))
+            .map(|val| postcard::from_bytes::<V>(val.as_ref()).map_err(|e| anyhow!(e)))
     }
 }
 
@@ -1961,7 +1961,7 @@ where
             Some(Err(e)) => return Some(Err(anyhow::Error::new(e))),
             Some(Ok(item)) => Some(item),
         };
-        item.map(|(key, v)| match bincode::deserialize::<V>(v.as_ref()) {
+        item.map(|(key, v)| match postcard::from_bytes::<V>(v.as_ref()) {
             Ok(v) => Ok((key, v)),
             Err(e) => Err(anyhow::Error::new(e)),
         })

--- a/src/storage_sled.rs
+++ b/src/storage_sled.rs
@@ -1663,7 +1663,7 @@ impl StorageDB for SledStorageDB {
         K: AsRef<[u8]> + Sync + Send,
         V: serde::ser::Serialize + Sync + Send,
     {
-        let val = bincode::serialize(val)?;
+        let val = postcard::to_stdvec(&val)?;
         let (tx, rx) = oneshot::channel();
         self.cmd_send(Command::DBInsert(
             self.clone(),
@@ -1687,7 +1687,7 @@ impl StorageDB for SledStorageDB {
         self.cmd_send(Command::DBGet(self.clone(), key.as_ref().into(), tx))
             .await?;
         match rx.await?? {
-            Some(v) => Ok(Some(bincode::deserialize::<V>(v.as_ref())?)),
+            Some(v) => Ok(Some(postcard::from_bytes::<V>(v.as_ref())?)),
             None => Ok(None),
         }
     }
@@ -1718,7 +1718,7 @@ impl StorageDB for SledStorageDB {
         let key_vals = key_vals
             .into_iter()
             .map(|(k, v)| {
-                bincode::serialize(&v)
+                postcard::to_stdvec(&v)
                     .map(|v| (k, v.into()))
                     .map_err(|e| anyhow!(e))
             })
@@ -2536,7 +2536,7 @@ impl Map for SledStorageMap {
         K: AsRef<[u8]> + Sync + Send,
         V: Serialize + Sync + Send + ?Sized,
     {
-        let val = bincode::serialize(val)?;
+        let val = postcard::to_stdvec(&val)?;
         let (tx, rx) = oneshot::channel();
         self.db
             .cmd_send(Command::MapInsert(
@@ -2563,7 +2563,7 @@ impl Map for SledStorageMap {
             .await?;
 
         match rx.await?? {
-            Some(v) => Ok(Some(bincode::deserialize::<V>(v.as_ref())?)),
+            Some(v) => Ok(Some(postcard::from_bytes::<V>(v.as_ref())?)),
             None => Ok(None),
         }
     }
@@ -2643,7 +2643,7 @@ impl Map for SledStorageMap {
             .await?;
 
         match rx.await?? {
-            Some(v) => Ok(Some(bincode::deserialize::<V>(v.as_ref())?)),
+            Some(v) => Ok(Some(postcard::from_bytes::<V>(v.as_ref())?)),
             None => Ok(None),
         }
     }
@@ -2675,7 +2675,7 @@ impl Map for SledStorageMap {
         let key_vals = key_vals
             .into_iter()
             .map(|(k, v)| {
-                bincode::serialize(&v)
+                postcard::to_stdvec(&v)
                     .map(|v| (k.into(), v.into()))
                     .map_err(|e| anyhow!(e))
             })
@@ -2927,7 +2927,7 @@ impl SledStorageList {
         K: AsRef<[u8]>,
     {
         if let Some(v) = tx.get(list_count_key.as_ref())? {
-            let (start, end) = bincode::deserialize::<(usize, usize)>(v.as_ref()).map_err(|e| {
+            let (start, end) = postcard::from_bytes::<(usize, usize)>(v.as_ref()).map_err(|e| {
                 ConflictableTransactionError::Storage(sled::Error::Io(io::Error::new(
                     ErrorKind::InvalidData,
                     e,
@@ -2950,7 +2950,7 @@ impl SledStorageList {
     where
         K: AsRef<[u8]>,
     {
-        let count_bytes = bincode::serialize(&(start, end)).map_err(|e| {
+        let count_bytes = postcard::to_stdvec(&(start, end)).map_err(|e| {
             ConflictableTransactionError::Storage(sled::Error::Io(io::Error::new(
                 ErrorKind::InvalidData,
                 e,
@@ -3306,7 +3306,7 @@ impl SledStorageList {
             } else {
                 let list_count_key = this.make_list_count_key();
                 if let Some(v) = this.tree().get(list_count_key.as_slice())? {
-                    let (start, end) = bincode::deserialize::<(usize, usize)>(v.as_ref())?;
+                    let (start, end) = postcard::from_bytes::<(usize, usize)>(v.as_ref())?;
                     Ok(end - start)
                 } else {
                     Ok(0)
@@ -3408,7 +3408,7 @@ impl List for SledStorageList {
     where
         V: serde::ser::Serialize + Sync + Send,
     {
-        let val = bincode::serialize(val)?;
+        let val = postcard::to_stdvec(&val)?;
         let (tx, rx) = oneshot::channel();
         self.db
             .cmd_send(Command::ListPush(self.clone(), val.into(), tx))
@@ -3430,7 +3430,7 @@ impl List for SledStorageList {
         let vals = vals
             .into_iter()
             .map(|v| {
-                bincode::serialize(&v)
+                postcard::to_stdvec(&v)
                     .map(|v| v.into())
                     .map_err(|e| anyhow!(e))
             })
@@ -3456,7 +3456,7 @@ impl List for SledStorageList {
         V: serde::ser::Serialize + Sync + Send,
         V: DeserializeOwned,
     {
-        let data = bincode::serialize(val)?;
+        let data = postcard::to_stdvec(&val)?;
 
         let (tx, rx) = oneshot::channel();
         self.db
@@ -3471,7 +3471,7 @@ impl List for SledStorageList {
 
         let removed = if let Some(removed) = rx.await?? {
             Some(
-                bincode::deserialize::<V>(removed.as_ref())
+                postcard::from_bytes::<V>(removed.as_ref())
                     .map_err(|e| sled::Error::Io(io::Error::new(ErrorKind::InvalidData, e)))?,
             )
         } else {
@@ -3491,7 +3491,7 @@ impl List for SledStorageList {
 
         let removed = if let Some(removed) = rx.await?? {
             Some(
-                bincode::deserialize::<V>(removed.as_ref())
+                postcard::from_bytes::<V>(removed.as_ref())
                     .map_err(|e| sled::Error::Io(io::Error::new(ErrorKind::InvalidData, e)))?,
             )
         } else {
@@ -3511,7 +3511,7 @@ impl List for SledStorageList {
 
         rx.await??
             .iter()
-            .map(|v| bincode::deserialize::<V>(v.as_ref()).map_err(|e| anyhow!(e)))
+            .map(|v| postcard::from_bytes::<V>(v.as_ref()).map_err(|e| anyhow!(e)))
             .collect::<Result<Vec<_>>>()
     }
 
@@ -3527,7 +3527,7 @@ impl List for SledStorageList {
             .await?;
 
         Ok(if let Some(res) = rx.await?? {
-            Some(bincode::deserialize::<V>(res.as_ref()).map_err(|e| anyhow!(e))?)
+            Some(postcard::from_bytes::<V>(res.as_ref()).map_err(|e| anyhow!(e))?)
         } else {
             None
         })
@@ -3659,7 +3659,7 @@ where
             Some(Err(e)) => Some(Err(anyhow::Error::new(e))),
             Some(Ok((k, v))) => {
                 let name = k.as_ref()[self.prefix_len..].to_vec();
-                match bincode::deserialize::<V>(v.as_ref()) {
+                match postcard::from_bytes::<V>(v.as_ref()) {
                     Ok(v) => {
                         self.iter = Some(iter);
                         Some(Ok((name, v)))
@@ -3757,7 +3757,7 @@ where
             Some(Err(e)) => Some(Err(anyhow::Error::new(e))),
             Some(Ok((_k, v))) => {
                 self.iter = Some(iter);
-                Some(bincode::deserialize::<V>(v.as_ref()).map_err(|e| anyhow!(e)))
+                Some(postcard::from_bytes::<V>(v.as_ref()).map_err(|e| anyhow!(e)))
             }
         }
     }


### PR DESCRIPTION
- Replace bincode with postcard 1.1 across all storage backends
- Update Redis, Redis Cluster, and Sled storage implementations
- Update API: serialize → postcard::to_stdvec, deserialize → postcard::from_bytes
- Bump rmqtt-storage version from 0.7.4 to 0.8.0